### PR TITLE
set HostWorkingDir to false

### DIFF
--- a/commands/web/frontend
+++ b/commands/web/frontend
@@ -5,7 +5,7 @@
 ## Usage: frontend [flags] [args]
 ## Example: "ddev frontend"
 ## ExecRaw: true
-## HostWorkingDir: true
+## HostWorkingDir: false
 
 # shellcheck source=woodoo_components/variables
 source ".ddev/commands/web/woodoo_components/variables"


### PR DESCRIPTION
Setting `HostWorkingDir` to false ensures that the command always works, no matter what path you are on the host machine.

Otherwise, it will fail due to inclusions that cannot be found like `/mnt/ddev_config/commands/web/frontend: line 11: .ddev/commands/web/woodoo_components/variables: No such file or directory`