### PR TITLE
Add magshare command for ngrok URL retrieval and Magento base URL update

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,22 @@ Command:
   build -f                Builds all themes without yes/no question (force)
   build Vendor/theme      Build a specific theme
   watch Vendor/theme      Watch for CSS and JS changes in a specific theme
+  magshare                Share Magento project using ngrok and update base URL
 
 Option:
   -f                      Builds all themes without yes/no question (force)
   themecode               Theme-Code from .ddev/config.yaml
 ```
+
+## Example
+
+To share your Magento project using ngrok and update the base URL, use the following command:
+
+```shell
+ddev magshare
+```
+
+This command will start ngrok, retrieve the forward URL, and update the local Magento base URL accordingly.
 
 ## Feature request
 

--- a/commands/web/magshare
+++ b/commands/web/magshare
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+## Description: Share Magento project using ngrok and update base URL
+## Usage: ddev magshare
+## Example: "ddev magshare"
+## ExecRaw: true
+## HostWorkingDir: false
+
+# Start ngrok and retrieve the forward URL
+NGROK_URL=$(ddev share | grep -o 'https://[a-zA-Z0-9.-]*\.ngrok\.io')
+
+if [ -z "$NGROK_URL" ]; then
+  echo "Failed to retrieve ngrok URL"
+  exit 1
+fi
+
+# Update Magento base URL
+ddev exec bin/magento config:set web/unsecure/base_url "$NGROK_URL/"
+ddev exec bin/magento config:set web/secure/base_url "$NGROK_URL/"
+ddev exec bin/magento cache:flush
+
+echo "Magento base URL updated to $NGROK_URL"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -40,3 +40,18 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
+
+@test "magshare command updates Magento base URL" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+  ddev get ${DIR}
+  ddev restart
+  run ddev magshare
+  [ "$status" -eq 0 ]
+  run ddev exec bin/magento config:show web/unsecure/base_url
+  [ "$status" -eq 0 ]
+  [[ "$output" == https://*.ngrok.io/ ]]
+  run ddev exec bin/magento config:show web/secure/base_url
+  [ "$status" -eq 0 ]
+  [[ "$output" == https://*.ngrok.io/ ]]
+}


### PR DESCRIPTION
Related to #26

Add support for `ddev share` with automatic config import for ngrok domains in Magento projects.

* **New Command:**
  - Add a new custom command `ddev magshare` in `commands/web/magshare` to handle ngrok URL retrieval and Magento base URL update.
  - Retrieve the ngrok forward URL using `ddev share`.
  - Update the local Magento base URL with the retrieved ngrok URL.
* **Documentation:**
  - Update `README.md` to include instructions on using the new `ddev magshare` command.
  - Include an example of how to use the `ddev magshare` command.
* **Testing:**
  - Add a test case in `tests/test.bats` to verify the functionality of the `ddev magshare` command.
  - Ensure the test case checks the retrieval of the ngrok URL and the update of the Magento base URL.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dermatz/ddev-woodoo-buildtools-magento/issues/26?shareId=e4b2d552-a1ac-435e-ac7d-aa464b244502).