### PR TITLE
Add alias annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-### UNRELEASED
+## UNRELEASED
+
 -   added alias annotations for 'ddev f' and 'ddev fe' commands in `commands/web/frontend`
 -   updated `README.md` to mention the aliases 'ddev f' and 'ddev fe' for the frontend commands
 -   updated `commands/web/woodoo_components/help` to list the aliases 'ddev f' and 'ddev fe' for the frontend commands
@@ -12,7 +13,9 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## Latest Release
+
 ### 1.7.0
+
 -   updated `README.md` - Thanks to [@t-muir] & [@Morgy93]
 -   updated Supporter in `README.md` - Thanks to [@tniebergall]
 -   updated `.trunk` linter settings
@@ -26,13 +29,15 @@ All notable changes to this project will be documented in this file.
 -   remove "whats new" hint for older Woodoo Versions (comes with 1.4.0)
 -   add `.vscode` settings file
 
-This release has __no braking changes__ and is fully compatible with existing `.ddev/config-themes.yaml`
+This release has **no braking changes** and is fully compatible with existing `.ddev/config-themes.yaml`
 
 ### 1.6.5
+
 -   fix an issue when reading `..theme/composer.json` to determine which Hyva version to use through composer.json
 -   add some GitHub Status-Badges to `README.md`
 
 ### 1.6.4
+
 -   updating wording - Thanks to @andreas-penner-basecom
 -   changed wget command to install latest version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### UNRELEASED
+-   added alias annotations for 'ddev f' and 'ddev fe' commands in `commands/web/frontend`
+-   updated `README.md` to mention the aliases 'ddev f' and 'ddev fe' for the frontend commands
+-   updated `commands/web/woodoo_components/help` to list the aliases 'ddev f' and 'ddev fe' for the frontend commands
+
+---
+
 ## Latest Release
 ### 1.7.0
 -   updated `README.md` - Thanks to [@t-muir] & [@Morgy93]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Command:
 
 Option:
   -f                    Force the build command to run without yes/no confirmation
+
+Aliases:
+  f, fe
 ```
 
 ## Feature request

--- a/commands/web/frontend
+++ b/commands/web/frontend
@@ -4,6 +4,7 @@
 ## Description: Run the frontend command inside the web container
 ## Usage: frontend [flags] [args]
 ## Example: "ddev frontend"
+## Aliases: f, fe
 ## ExecRaw: true
 ## HostWorkingDir: false
 

--- a/commands/web/woodoo_components/help
+++ b/commands/web/woodoo_components/help
@@ -34,7 +34,7 @@ if [[ ${found} == true ]]; then
     echo -e "  ${txtylw}-f${txtrst}                    Force the build command to run without yes/no confirmation\n"
 
     echo -e "${txtylw}\nAliases:${txtrst}"
-    echo -e "  ${txtylw}f, fe${txtrst}\n"
+    echo -e "  f, fe"
 
     if [[ -n ${THEMES_IN_CONFIG} ]]; then
         echo -e "${txtpur}\nAvailable themes:${txtrst}"

--- a/commands/web/woodoo_components/help
+++ b/commands/web/woodoo_components/help
@@ -33,6 +33,9 @@ if [[ ${found} == true ]]; then
     echo -e "${txtylw}\nOption:${txtrst}"
     echo -e "  ${txtylw}-f${txtrst}                    Force the build command to run without yes/no confirmation\n"
 
+    echo -e "${txtylw}\nAliases:${txtrst}"
+    echo -e "  ${txtylw}f, fe${txtrst}\n"
+
     if [[ -n ${THEMES_IN_CONFIG} ]]; then
         echo -e "${txtpur}\nAvailable themes:${txtrst}"
         for THEME_CODE in ${THEMES_IN_CONFIG}; do


### PR DESCRIPTION
Related to #34

Add alias annotations for 'ddev f' and 'ddev fe' commands.

* **commands/web/frontend**
  - Add alias annotations for 'ddev f' and 'ddev fe' commands.
* **README.md**
  - Mention the aliases 'ddev f' and 'ddev fe' for the frontend commands in the usage section.
* **CHANGELOG.md**
  - Reflect changes related to the addition of alias annotations for 'ddev f' and 'ddev fe' commands.
* **commands/web/woodoo_components/help**
  - List the aliases 'ddev f' and 'ddev fe' for the frontend commands in the help options.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dermatz/ddev-woodoo-buildtools-magento/issues/34?shareId=fd9a8f57-6e2d-4564-886f-06be22e0742c).