### PR TITLE
#44 - add Color Assignments to CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED 1.9.0
 
 -   added documentation for color assignments in `CONTRIBUTING.md` to standardize the use of color variables in bash scripts
--   added provided detailed color definitions and a usage example in the new "Color Assignments" section
+-   added detailed color definitions and a usage example in the new "Color Assignments" section
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### 1.8.0
 
 -   added alias annotations for 'ddev f' and 'ddev fe' commands in `commands/web/frontend` (_requires DDEV >= 1.23.4_) [@Morgy93]
--   added housekeeping task to `install.yaml` to `pre_install_actions` and remove old checks file if exists
+-   added housekeeping task to `install.yaml` and `pre_install_actions` and removed old check if file exists
 -   updated `README.md` to mention the aliases 'ddev f' and 'ddev fe' for the frontend commands [@Morgy93]
 -   updated `README.md` with usage examples [@Morgy93]
 -   updated `commands/web/woodoo_components/help` to list the aliases 'ddev f' and 'ddev fe' for the frontend commands [@Morgy93]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED 1.9.0
 
+-   added documentation for color assignments in `CONTRIBUTING.md` to standardize the use of color variables in bash scripts
+-   added provided detailed color definitions and a usage example in the new "Color Assignments" section
+
 ---
 
 ## Latest Release
@@ -13,14 +16,13 @@ All notable changes to this project will be documented in this file.
 ### 1.8.0
 
 -   added alias annotations for 'ddev f' and 'ddev fe' commands in `commands/web/frontend` (_requires DDEV >= 1.23.4_) [@Morgy93]
+-   added housekeeping task to `install.yaml` to `pre_install_actions` and remove old checks file if exists
 -   updated `README.md` to mention the aliases 'ddev f' and 'ddev fe' for the frontend commands [@Morgy93]
 -   updated `README.md` with usage examples [@Morgy93]
 -   updated `commands/web/woodoo_components/help` to list the aliases 'ddev f' and 'ddev fe' for the frontend commands [@Morgy93]
 -   refactored 'commands/web/woodoo_components/functions` to add all woodoo functions to this file
 -   remove `commands/web/woodoo_components/checks` (was moved to `functions`)
 -   remove not valid characters in `.vscode/settings.json`
--   add housekeeping task to `install.yaml` to `pre_install_actions` and remove old checks file if exists
-
 
 ### 1.7.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,9 @@ txtrst='\033[0m' # Text Reset
 
 **Result:**
 
-<div style="background-color: #1E293B;color: white; font-family:courier;border:1px solid #64748B;padding:10px;border-radius:5px; margin: 10px 0 20px;">$ Thank <span style="color:green">you</span> for use <span style="color:cyan">Woodoo Buildtools</span>!</div>
+<div style="background-color:#1E293B;color:white;font-family:courier;border:1px solid #64748B;padding:10px;border-radius:5px;margin: 10px 0 20px;">
+   Thank <span style="color:green">you</span> for use <span style="color:cyan">Woodoo Buildtools</span>!
+</div>
 
 Use `${txtrst}` to reset the color back to default terminal color.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 ## Submit Pull-Requests
 
 -   Create an [Issue](https://github.com/dermatz/ddev-woodoo-buildtools-magento/issues) as either a feature request or bug report. Please ensure the ticket includes all relevant information
--   Fork this Project and create a new branch for your work and releated to your ticket
+-   Fork this project, then create a new branch for your work that is related to the issue you created
 -   Commit your changes to the new branch and open a Pull Request to this repository branch: `main`
 
 ## Coding Quality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,12 +111,12 @@ txtrst='\033[0m' # Text Reset
 
 ### Usage
 
-**Example:** `echo -n "Thank ${txtgrn}you${txtrst} for use ${txtcyn}Woodoo Buildtools${txtrst}!"`
+**Example:** `echo -n "Thank ${txtgrn}you${txtrst} for using ${txtcyn}Woodoo Buildtools${txtrst}!"`
 
 **Result:**
 
 <div style="background-color:#1E293B;color:white;font-family:courier;border:1px solid #64748B;padding:10px;border-radius:5px;margin: 10px 0 20px;">
-   Thank <span style="color:green">you</span> for use <span style="color:cyan">Woodoo Buildtools</span>!
+   Thank <span style="color:green">you</span> for using <span style="color:cyan">Woodoo Buildtools</span>!
 </div>
 
 Use `${txtrst}` to reset the color back to default terminal color.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,14 @@
 
 ## Submit Pull-Requests
 
--   Create an [Issue](https://github.com/dermatz/ddev-woodoo-buildtools-magento/issues)
--   Fork this Project and create a new branch for your work
+-   Create an [Issue](https://github.com/dermatz/ddev-woodoo-buildtools-magento/issues) as Feature-Request or Bug-Report and fill the ticket with all information
+-   Fork this Project and create a new branch for your work and releated to your ticket
 -   Commit your changes to the new branch and open a Pull Request to this repository branch: `main`
 
 ## Coding Quality
 
 -   Use the Bash Standard for ddev commands
+-   Run `trunk check` to validate your code against our coding rules, otherwise our pipeline will do that ;)
 -   Use the Magento Coding Standard
 -   Use the Magento Coding Standard for PHP
 -   Use the Magento Coding Standard for HTML
@@ -20,10 +21,6 @@
 -   Use the Magento Coding Standard for XML
 -   Use the Magento Coding Standard for LESS
 -   Use the Magento Coding Standard for CSS
-
-## Language
-
--   Use Shell only
 
 ## Documentation
 
@@ -34,6 +31,8 @@
 a) This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details
 b) All of your contributions will be also licensed under the MIT License
 
+---
+
 ## Code Formatting
 
 -   Indent code with 4 spaces
@@ -41,11 +40,85 @@ b) All of your contributions will be also licensed under the MIT License
 -   Keep lines under 80 characters where possible
 -   User `trunk check` to lint your code
 
+---
+
 ## Naming Conventions
 
 -   Use camelCase for variable and function names
 -   Use UPPER_CASE for constants
 -   Use descriptive names for functions and variables
+
+---
+
+## Color Assignments
+
+In this project, we define color variables in [`commands/web/woodoo_components/variables`](../commands/web/woodoo_components/variables) and use them in our bash scripts for consistent terminal output. Below are the color assignments:
+
+-   **cyan**: Used for CLI commands.
+-   **purple**: Used for theme names.
+-   **yellow**: Used for warnings.
+-   **red**: Used for errors.
+-   **white**: Used for general output (default terminal color).
+
+### Color Definitions
+
+Here is an example of how these colors are defined in [`commands/web/woodoo_components/variables`](../commands/web/woodoo_components/variables):
+
+```bash
+# Regular
+txtblk='\033[0;30m' # Black
+txtred='\033[0;31m' # Red
+txtgrn='\033[0;32m' # Green
+txtylw='\033[0;33m' # Yellow
+txtblu='\033[0;34m' # Blue
+txtpur='\033[0;35m' # Purple
+txtcyn='\033[0;36m' # Cyan
+txtwht='\033[0;37m' # White
+
+# Bold
+bldblk='\033[1;30m' # Black
+bldred='\033[1;31m' # Red
+bldgrn='\033[1;32m' # Green
+bldylw='\033[1;33m' # Yellow
+bldblu='\033[1;34m' # Blue
+bldpur='\033[1;35m' # Purple
+bldcyn='\033[1;36m' # Cyan
+bldwht='\033[1;37m' # White
+
+# Underline
+unkblk='\033[4;30m' # Black
+undred='\033[4;31m' # Red
+undgrn='\033[4;32m' # Green
+undylw='\033[4;33m' # Yellow
+undblu='\033[4;34m' # Blue
+undpur='\033[4;35m' # Purple
+undcyn='\033[4;36m' # Cyan
+undwht='\033[4;37m' # White
+
+# Text with Background
+bakblk='\033[40m' # Black
+bakred='\033[41m' # Red
+bakgrn='\033[42m' # Green
+bakylw='\033[43m' # Yellow
+bakblu='\033[44m' # Blue
+bakpur='\033[45m' # Purple
+bakcyn='\033[46m' # Cyan
+bakwht='\033[47m' # White
+
+# reset color to default
+txtrst='\033[0m' # Text Reset
+```
+
+### Usage
+
+**Example:** `echo -n "Thank ${txtgrn}you${txtrst} for use ${txtcyn}Woodoo Buildtools${txtrst}!"`
+
+**Result:**
+<div style="background-color: #1E293B;color: white; font-family:courier;border:1px solid #64748B;padding:10px;border-radius:5px; margin: 10px 0 20px;">$ Thank <span style="color:green">you</span> for use <span style="color:cyan">Woodoo Buildtools</span>!</div>
+
+Use `${txtrst}` to reset the color back to default terminal color.
+
+---
 
 ## Best Practices
 
@@ -54,6 +127,8 @@ b) All of your contributions will be also licensed under the MIT License
 -   Use functions to encapsulate code
 -   Test your code thoroughly before submitting
 -   Add Description to functions and describe parameters
+
+---
 
 ## Code Review Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 ## Submit Pull-Requests
 
--   Create an [Issue](https://github.com/dermatz/ddev-woodoo-buildtools-magento/issues) as Feature-Request or Bug-Report and fill the ticket with all information
+-   Create an [Issue](https://github.com/dermatz/ddev-woodoo-buildtools-magento/issues) as either a feature request or bug report. Please ensure the ticket includes all relevant information
 -   Fork this Project and create a new branch for your work and releated to your ticket
 -   Commit your changes to the new branch and open a Pull Request to this repository branch: `main`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ txtrst='\033[0m' # Text Reset
 **Example:** `echo -n "Thank ${txtgrn}you${txtrst} for use ${txtcyn}Woodoo Buildtools${txtrst}!"`
 
 **Result:**
+
 <div style="background-color: #1E293B;color: white; font-family:courier;border:1px solid #64748B;padding:10px;border-radius:5px; margin: 10px 0 20px;">$ Thank <span style="color:green">you</span> for use <span style="color:cyan">Woodoo Buildtools</span>!</div>
 
 Use `${txtrst}` to reset the color back to default terminal color.


### PR DESCRIPTION
This pull request adds a new section to the `CONTRIBUTING.md` file to document the color assignments used in our bash scripts. The new section provides detailed information on the purpose of each color and includes examples of how these colors are defined in the project.

## Changes
Added a new section "Color Assignments" to `CONTRIBUTING.md`

## Describes the purpose of each color used in the project.
Provides examples of color definitions from the `commands/web/woodoo_components/variables` file.
Detailed Color Definitions:

## Lists the ANSI escape codes for regular, bold, and underlined text colors.
Ensures that contributors understand how to use these color variables in their scripts.

## Motivation
The addition of this documentation aims to:

Improve code readability and maintainability by standardizing the use of color variables.
Help new contributors understand the project's conventions for terminal output.
Ensure consistent use of colors across all bash scripts in the project.