### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,27 @@ _>> Build all your Magento themes at once, with Magic, build with Woodoo!_
 
 ##### Latest stable version (recommended)
 
+For DDEV v1.23.5 or above run
+
+```shell
+ddev add-on get dermatz/ddev-woodoo-buildtools-magento
+```
+
+For earlier versions of DDEV run
+
 ```shell
 ddev get dermatz/ddev-woodoo-buildtools-magento
 ```
 
 ##### Latest Developer-Preview (Main-Branch - unreleased) - can be instable!
+
+For DDEV v1.23.5 or above run
+
+```shell
+ddev add-on get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/heads/main.tar.gz
+```
+
+For earlier versions of DDEV run
 
 ```shell
 ddev get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/heads/main.tar.gz


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.