### PR TITLE
Update DDEV addon command to use ddev add-on get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED 1.9.0
 
+-   Updated to use `ddev add-on get` for versions of DDEV prior to v1.23.5
+
 ---
 
 ## Latest Release

--- a/commands/host/frontend-update
+++ b/commands/host/frontend-update
@@ -10,7 +10,7 @@
 LATEST_WOODOO_VERSION=$(curl -s https://api.github.com/repos/dermatz/ddev-woodoo-buildtools-magento/releases/latest | grep tag_name | cut -d '"' -f 4)
 
 if [[ $1 == "-dev" ]]; then
-    ddev get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/heads/main.tar.gz
+    ddev add-on get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/heads/main.tar.gz
 else
-    ddev get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/tags/"${LATEST_WOODOO_VERSION}".tar.gz
+    ddev add-on get https://github.com/dermatz/ddev-woodoo-buildtools-magento/archive/refs/tags/"${LATEST_WOODOO_VERSION}".tar.gz
 fi

--- a/install.yaml
+++ b/install.yaml
@@ -2,7 +2,7 @@ name: ddev-woodoo-buildtools-magento
 
 pre_install_actions:
     # https://github.com/Morgy93/ddev-gum
-    - if ! ddev get --installed | grep -q "Morgy93/ddev-gum"; then ddev get Morgy93/ddev-gum; fi
+    - if ! ddev add-on get --installed | grep -q "Morgy93/ddev-gum"; then ddev add-on get Morgy93/ddev-gum; fi
     - "if [ -f .ddev/commands/web/woodoo_components/checks ]; then rm .ddev/commands/web/woodoo_components/checks && echo 'Woodoo Housekeeping: removed old file .ddev/commands/web/woodoo_components/checks'; fi"
 
 project_files:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -35,8 +35,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DDEV_ADDON}
+  echo "# ddev add-on get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DDEV_ADDON}
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
Update commands and tests to use `ddev add-on get` instead of `ddev get`.

* **commands/host/frontend-update**
  - Change `ddev get` to `ddev add-on get` for fetching the latest version of the addon.
* **install.yaml**
  - Update pre-install actions to use `ddev add-on get` instead of `ddev get`.
* **tests/test.bats**
  - Modify installation tests to use `ddev add-on get` instead of `ddev get`.
* **CHANGELOG.md**
  - Add an entry to document the update to use `ddev add-on get` for versions of DDEV prior to v1.23.5.

